### PR TITLE
Allow array of donor roles in discords.json

### DIFF
--- a/modules/filtering/commands.js
+++ b/modules/filtering/commands.js
@@ -27,7 +27,7 @@ module.exports.run = async (MAIN, BOT, message) => {
 
       // FETCH THE GUILD MEMBER AND CHECK IF A DONOR
       if(isAdmin){ /* DO NOTHING */ }
-      else if(server.donor_role && !member.roles.has(server.donor_role)){
+      else if(server.donor_role && (!member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)))){
         let donor_info = '';
         if(MAIN.config.log_channel){
           let nondonor_embed = new MAIN.Discord.RichEmbed()
@@ -88,7 +88,7 @@ module.exports.run = async (MAIN, BOT, message) => {
 
       // FETCH THE GUILD MEMBER AND CHECK IF A DONOR
       if(isAdmin || isMod){ /* DO NOTHING */ }
-      else if(server.donor_role && !member.roles.has(server.donor_role)){
+      else if(server.donor_role && (!member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)))){
         if(MAIN.config.log_channel){
           let donor_info = '';
           let nondonor_embed = new MAIN.Discord.RichEmbed()

--- a/modules/subscriptions/invasion.js
+++ b/modules/subscriptions/invasion.js
@@ -17,7 +17,7 @@ module.exports.run = async (MAIN, invasion, area, server, timezone) => {
           case !member:
           case member == undefined: return;
           case MAIN.config.Donor_Check == 'DISABLED': break;
-          case !member.roles.has(server.donor_role): return;
+          case !member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)): return;
         }
 
         // DEFINE VARIABLES

--- a/modules/subscriptions/lure.js
+++ b/modules/subscriptions/lure.js
@@ -18,7 +18,7 @@ module.exports.run = async (MAIN, lure, area, server, timezone) => {
           case !member:
           case member == undefined: return;
           case MAIN.config.Donor_Check == 'DISABLED': break;
-          case !member.roles.has(server.donor_role): return;
+          case !member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)): return;
         }
 
         // DEFINE VARIABLES

--- a/modules/subscriptions/pokemon.js
+++ b/modules/subscriptions/pokemon.js
@@ -22,7 +22,7 @@ module.exports.run = async (MAIN, sighting, area, server, timezone) => {
           case !member:
           case member == undefined: return;
           case MAIN.config.Donor_Check == 'DISABLED': break;
-          case !member.roles.has(server.donor_role): return;
+          case !member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)): return;
         }
 
         // DEFINE VARIABLES

--- a/modules/subscriptions/pvp.js
+++ b/modules/subscriptions/pvp.js
@@ -23,7 +23,7 @@ module.exports.run = async (MAIN, sighting, area, server, timezone) => {
           case !member:
           case member == undefined: return;
           case MAIN.config.Donor_Check == 'DISABLED': break;
-          case !member.roles.has(server.donor_role): return;
+          case !member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)): return;
         }
 
         // DEFINE VARIABLES

--- a/modules/subscriptions/quests.js
+++ b/modules/subscriptions/quests.js
@@ -29,7 +29,7 @@ module.exports.run = async (MAIN, quest, area, server, timezone) => {
           case !member:
           case member == undefined: return;
           case MAIN.config.Donor_Check == 'DISABLED': break;
-          case !member.roles.has(server.donor_role): return;
+          case !member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)): return;
         }
 
         // DEFINE VARIABLES

--- a/modules/subscriptions/raids.js
+++ b/modules/subscriptions/raids.js
@@ -37,7 +37,7 @@ module.exports.run = async (MAIN, raid, area, server, timezone) => {
           case !member:
           case member == undefined: return;
           case MAIN.config.Donor_Check == 'DISABLED': break;
-          case !member.roles.has(server.donor_role): return;
+          case !member.roles.has(server.donor_role) && !member.roles.some(r=>server.donor_role.includes(r.id)): return;
         }
 
         // DEFINE VARIABLES


### PR DESCRIPTION
If you have multiple donor roles in your server, this will allow you to set an array of roles in discord.json. For example:

"donor_role": ["277658037982986240", "123456789101112131415"],

This will not break the way that donor_role is currently checked. 