### PR TITLE
Change Form Minimum for Bypass

### DIFF
--- a/src/commands/subscription/pokemon/create.js
+++ b/src/commands/subscription/pokemon/create.js
@@ -36,7 +36,7 @@ module.exports = (WDR, Functions, Message, Member, advanced) => {
           create.pokemon_id = 0;
         }
 
-        if (create.pokemon_id > 0 && create.form_ids.length > 3) {
+        if (create.pokemon_id > 0 && create.forms.length > 1) {
           create.form = await Functions.DetailCollect(WDR, Functions, "Form", Member, Message, null, "Please respond with the displayed number of the form -OR- type 'All'. Type 'Cancel' to Stop.", create);
         } else {
           create.form = 0;

--- a/src/commands/subscription/pokemon/create.js
+++ b/src/commands/subscription/pokemon/create.js
@@ -36,7 +36,7 @@ module.exports = (WDR, Functions, Message, Member, advanced) => {
           create.pokemon_id = 0;
         }
 
-        if (create.pokemon_id > 0 && create.form_ids.length > 1) {
+        if (create.pokemon_id > 0 && create.form_ids.length > 3) {
           create.form = await Functions.DetailCollect(WDR, Functions, "Form", Member, Message, null, "Please respond with the displayed number of the form -OR- type 'All'. Type 'Cancel' to Stop.", create);
         } else {
           create.form = 0;


### PR DESCRIPTION
This will allow all Pokemon to with only normal/shadow/purified forms to bypass the form selection portion of subscription creation. The only Pokemon negatively impacted by this that I could find is Basculin which is region exclusive.