### PR TITLE
Fixed bug that allowed multiple subscriptions to created/edited simultaneously

### DIFF
--- a/src/commands/subscription/area/collect_detail.js
+++ b/src/commands/subscription/area/collect_detail.js
@@ -99,9 +99,17 @@ module.exports = async (WDR, Functions, type, member, message, object, requireme
             // FILTER COLLECT EVENT
             collector.on('collect', CollectedMsg => {
 
-                CollectedMsg.delete();
+                if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+                    try {
+                        CollectedMsg.delete();
+                    // eslint-disable-next-line no-empty
+                    } catch (e) {
+
+                    }
+                }
 
                 switch (true) {
+                    case CollectedMsg.content.startsWith(WDR.Config.PREFIX):
                     case CollectedMsg.content.toLowerCase() == 'cancel':
                         collector.stop('cancel');
                         break;

--- a/src/commands/subscription/area/collect_option.js
+++ b/src/commands/subscription/area/collect_option.js
@@ -11,9 +11,15 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, AreaArray)
     // FILTER COLLECT EVENT
     collector.on('collect', CollectedMsg => {
 
-        if (BotMsg.channel.type != 'dm') {
-            CollectedMsg.delete();
+        if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX && BotMsg.channel.type != 'dm')) {
+            try {
+                CollectedMsg.delete();
+            // eslint-disable-next-line no-empty
+            } catch (e) {
+
+            }
         }
+
 
         switch (CollectedMsg.content.toLowerCase()) {
             case 'add':
@@ -28,6 +34,8 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, AreaArray)
             case 'cancel':
                 collector.stop('cancel');
                 break;
+            default:
+                collector.stop('cancel');
         }
     });
 
@@ -39,6 +47,8 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, AreaArray)
         }
 
         switch (msg) {
+            case 'cancel':
+                return Functions.Cancel(WDR, Functions, OriginalMsg, Member);
             case 'add':
                 return Functions.Add(WDR, Functions, OriginalMsg, Member, AreaArray);
             case 'distance':

--- a/src/commands/subscription/location/collect_detail.js
+++ b/src/commands/subscription/location/collect_detail.js
@@ -98,14 +98,17 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, l
 
             collector.on('collect', async CollectedMsg => {
 
-                try {
-                    CollectedMsg.delete();
-                // eslint-disable-next-line no-empty
-                } catch (e) {
+                if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+                    try {
+                        CollectedMsg.delete();
+                    // eslint-disable-next-line no-empty
+                    } catch (e) {
 
+                    }
                 }
 
                 switch (true) {
+                    case CollectedMsg.content.startsWith(WDR.Config.PREFIX):
                     case CollectedMsg.content.toLowerCase() == 'cancel':
                         collector.stop('cancel');
                         break;

--- a/src/commands/subscription/location/collect_option.js
+++ b/src/commands/subscription/location/collect_option.js
@@ -10,11 +10,13 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, AreaArray)
     // FILTER COLLECT EVENT
     collector.on('collect', CollectedMsg => {
 
-        try {
-            CollectedMsg.delete();
-        // eslint-disable-next-line no-empty
-        } catch (e) {
+        if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+            try {
+                CollectedMsg.delete();
+            // eslint-disable-next-line no-empty
+            } catch (e) {
 
+            }
         }
 
         switch (CollectedMsg.content.toLowerCase()) {
@@ -33,6 +35,8 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, AreaArray)
             case 'view':
                 collector.stop('view');
                 break;
+            default:
+                collector.stop('cancel');
         }
     });
 
@@ -49,6 +53,8 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, AreaArray)
         }
 
         switch (msg) {
+            case 'cancel':
+                return Functions.Cancel(WDR, Functions, OriginalMsg, Member);
             case 'create':
                 return Functions.Create(WDR, Functions, OriginalMsg, Member, AreaArray);
             case 'remove':

--- a/src/commands/subscription/pokemon/collect_detail.js
+++ b/src/commands/subscription/pokemon/collect_detail.js
@@ -169,16 +169,18 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, s
 
             collector.on('collect', async CollectedMsg => {
 
-                try {
-                    CollectedMsg.delete();
-                // eslint-disable-next-line no-empty
-                } catch (e) {
+                if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+                    try {
+                        CollectedMsg.delete();
+                    // eslint-disable-next-line no-empty
+                    } catch (e) {
 
+                    }
                 }
 
                 switch (true) {
 
-
+                    case CollectedMsg.content.startsWith(WDR.Config.PREFIX):
                     case CollectedMsg.content.toLowerCase() == 'stop':
                     case CollectedMsg.content.toLowerCase() == 'cancel':
                         collector.stop('cancel');

--- a/src/commands/subscription/pokemon/collect_option.js
+++ b/src/commands/subscription/pokemon/collect_option.js
@@ -9,14 +9,14 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member) => {
     });
 
     collector.on('collect', CollectedMsg => {
+        if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+            try {
+                CollectedMsg.delete();
+            // eslint-disable-next-line no-empty
+            } catch (e) {
 
-        try {
-            CollectedMsg.delete();
-        // eslint-disable-next-line no-empty
-        } catch (e) {
-
+            }
         }
-
         let input = CollectedMsg.content.split(' ').toString().toLowerCase();
 
         let adv_words = ['adv'],

--- a/src/commands/subscription/pvp/collect_detail.js
+++ b/src/commands/subscription/pvp/collect_detail.js
@@ -160,17 +160,20 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, s
             // FILTER COLLECT EVENT
             collector.on('collect', async CollectedMsg => {
 
-                try {
-                    CollectedMsg.delete();
-                // eslint-disable-next-line no-empty
-                } catch (e) {
+                if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+                    try {
+                        CollectedMsg.delete();
+                    // eslint-disable-next-line no-empty
+                    } catch (e) {
 
+                    }
                 }
 
                 let old_data;
 
                 switch (true) {
 
+                    case CollectedMsg.content.startsWith(WDR.Config.PREFIX):
                     case CollectedMsg.content.toLowerCase() == 'stop':
                     case CollectedMsg.content.toLowerCase() == 'cancel':
                         collector.stop('cancel');

--- a/src/commands/subscription/pvp/collect_option.js
+++ b/src/commands/subscription/pvp/collect_option.js
@@ -10,11 +10,13 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member) => {
 
     collector.on('collect', CollectedMsg => {
 
-        try {
-            CollectedMsg.delete();
-        // eslint-disable-next-line no-empty
-        } catch (e) {
+        if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+            try {
+                CollectedMsg.delete();
+            // eslint-disable-next-line no-empty
+            } catch (e) {
 
+            }
         }
 
         let input = CollectedMsg.content.split(' ')[0].toString().toLowerCase();

--- a/src/commands/subscription/quest/collect_detail.js
+++ b/src/commands/subscription/quest/collect_detail.js
@@ -80,15 +80,18 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, s
 
             collector.on('collect', async CollectedMsg => {
 
-                try {
-                    CollectedMsg.delete();
-                // eslint-disable-next-line no-empty
-                } catch (e) {
+                if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+                    try {
+                        CollectedMsg.delete();
+                    // eslint-disable-next-line no-empty
+                    } catch (e) {
 
+                    }
                 }
 
                 switch (true) {
 
+                    case CollectedMsg.content.startsWith(WDR.Config.PREFIX):
                     case CollectedMsg.content.toLowerCase() == 'stop':
                     case CollectedMsg.content.toLowerCase() == 'cancel':
                         collector.stop('cancel');
@@ -220,7 +223,16 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, s
 
                     }
                 }
-                return resolve(reason);
+                switch (reason) {
+                    case 'cancel':
+                        Functions.Cancel(WDR, Functions, Message, Member, 'Quest');
+                        return null;
+                    case 'time':
+                        Functions.TimedOut(WDR, Functions, Message, Member, 'Quest');
+                        return null;
+                    default:
+                        return resolve(reason);
+                }
             });
         });
     });

--- a/src/commands/subscription/quest/collect_option.js
+++ b/src/commands/subscription/quest/collect_option.js
@@ -10,11 +10,13 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member) => {
 
     collector.on('collect', CollectedMsg => {
 
-        try {
-            CollectedMsg.delete();
-        // eslint-disable-next-line no-empty
-        } catch (e) {
+        if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+            try {
+                CollectedMsg.delete();
+            // eslint-disable-next-line no-empty
+            } catch (e) {
 
+            }
         }
 
         let input = CollectedMsg.content.split(' ')[0].toString().toLowerCase();
@@ -50,6 +52,8 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member) => {
             case resume_words.some(word => input.includes(word)):
                 collector.stop('resume');
                 break;
+            default:
+                collector.stop('cancel');
         }
     });
 

--- a/src/commands/subscription/raid/collect_detail.js
+++ b/src/commands/subscription/raid/collect_detail.js
@@ -101,15 +101,17 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, s
             // FILTER COLLECT EVENT
             collector.on('collect', async CollectedMsg => {
 
-                try {
-                    CollectedMsg.delete();
-                // eslint-disable-next-line no-empty
-                } catch (e) {
+                if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+                    try {
+                        CollectedMsg.delete();
+                    // eslint-disable-next-line no-empty
+                    } catch (e) {
 
+                    }
                 }
 
                 switch (true) {
-
+                    case CollectedMsg.content.startsWith(WDR.Config.PREFIX):
                     case CollectedMsg.content.toLowerCase() == 'stop':
                     case CollectedMsg.content.toLowerCase() == 'cancel':
                         collector.stop('cancel');
@@ -316,7 +318,17 @@ module.exports = (WDR, Functions, type, Member, Message, object, requirements, s
 
                     }
                 }
-                return resolve(reason);
+
+                switch (reason) {
+                    case 'cancel':
+                        Functions.Cancel(WDR, Functions, Message, Member, 'Raid');
+                        return null;
+                    case 'time':
+                        Functions.TimedOut(WDR, Functions, Message, Member, 'Raid');
+                        return null;
+                    default:
+                        return resolve(reason);
+                }
             });
         });
     });

--- a/src/commands/subscription/raid/collect_option.js
+++ b/src/commands/subscription/raid/collect_option.js
@@ -10,11 +10,13 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, gym_name_a
 
     collector.on('collect', CollectedMsg => {
 
-        try {
-            CollectedMsg.delete();
-        // eslint-disable-next-line no-empty
-        } catch (e) {
+        if (!CollectedMsg.content.startsWith(WDR.Config.PREFIX)) {
+            try {
+                CollectedMsg.delete();
+            // eslint-disable-next-line no-empty
+            } catch (e) {
 
+            }
         }
 
         let input = CollectedMsg.content.split(' ')[0].toString().toLowerCase();
@@ -49,6 +51,8 @@ module.exports = (WDR, Functions, source, oMessage, bMessage, Member, gym_name_a
             case resume_words.some(word => input.includes(word)):
                 collector.stop('resume');
                 break;
+            default:
+                collector.stop('cancel');
         }
     });
 


### PR DESCRIPTION
If you were in the process of setting up a subscription (or had just viewed you subscription) and then entered a command to start a different subscription, collectors for both will be open and things get a bit confusing. This PR adds a check to see if a command entered during a subscription beings with the bot prefix. If it does, the current subscription will be canceled. Additionally, in this scenario both messages.js and collect_option.js or collect_detail.js would try to delete the same message, resulting in an error. I'm not sure why the try...catch doesn't work, but it wasn't. So I added another check for the bot prefix before collect_option.js or collect_detail.js tries to delete that message.